### PR TITLE
Fix task name

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This plugin uses the apache-cxf tools to do the actual work.
 
 | Name | Description | Dependecy |
 | ---- | ----------- | --------- |
-| wsdl2java | Generate java source from wsdl-files | CompileJava/CompileKotlin depends on wsdl2java |
+| wsdl2javaTask | Generate java source from wsdl-files | CompileJava/CompileKotlin depends on wsdl2java |
 
 ## Usage
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = 'com.yupzip'
-version = '2.0'
+version = '2.1'
 
 // stay compatible with the crowd
 sourceCompatibility = JavaVersion.VERSION_1_6

--- a/src/main/groovy/com/yupzip/wsdl2java/Wsdl2JavaPlugin.groovy
+++ b/src/main/groovy/com/yupzip/wsdl2java/Wsdl2JavaPlugin.groovy
@@ -7,6 +7,7 @@ import org.gradle.api.Task
 
 class Wsdl2JavaPlugin implements Plugin<Project> {
     public static final String WSDL2JAVA = "wsdl2java"
+    public static final String WSDL2JAVA_TASK = "wsdl2javaTask"
 
     private static final JAVA_9_DEPENDENCIES = [
             "javax.xml.bind:jaxb-api:2.3.1",
@@ -35,7 +36,7 @@ class Wsdl2JavaPlugin implements Plugin<Project> {
             }
         }
 
-        def wsdl2JavaTask = project.tasks.register(WSDL2JAVA, Wsdl2JavaTask.class) { task ->
+        def wsdl2JavaTask = project.tasks.register(WSDL2JAVA_TASK, Wsdl2JavaTask.class) { task ->
             wsdl2javaConfiguration.withDependencies {
                 it.add(project.dependencies.create("org.apache.cxf:cxf-tools-wsdlto-databinding-jaxb:${cxfVersion.get()}"))
                 it.add(project.dependencies.create("org.apache.cxf:cxf-tools-wsdlto-frontend-jaxws:${cxfVersion.get()}"))


### PR DESCRIPTION
Fixes the following error when referencing the `wsdl2java` task:

```Could not determine the dependencies of task ':compileJava'.
> Cannot convert extension 'wsdl2java' to a task.
  The following types/formats are supported:
    - A String or CharSequence task name or path
    - A Task instance
    - A TaskReference instance
    - A Buildable instance
    - A TaskDependency instance
    - A Provider that represents a task output
    - A Provider instance that returns any of these types
    - A Closure instance that returns any of these types
    - A Callable instance that returns any of these types
    - An Iterable, Collection, Map or array instance that contains any of these types
```

And enables us to do things like:

`dependsOn wsdl2javaTask`