### PR TITLE
Fix kotlin detection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = 'com.yupzip'
-version = '2.1'
+version = '2.11'
 
 // stay compatible with the crowd
 sourceCompatibility = JavaVersion.VERSION_1_6

--- a/src/main/groovy/com/yupzip/wsdl2java/Wsdl2JavaPlugin.groovy
+++ b/src/main/groovy/com/yupzip/wsdl2java/Wsdl2JavaPlugin.groovy
@@ -62,14 +62,8 @@ class Wsdl2JavaPlugin implements Plugin<Project> {
             it.dependsOn wsdl2JavaTask
         }
 
-        project.pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
-            project.tasks.withType(getTaskClass("org.jetbrains.kotlin.gradle.tasks.KotlinCompile")).configureEach {
-                it.dependsOn wsdl2JavaTask
-            }
-        }
-
-        project.pluginManager.withPlugin("org.jetbrains.kotlin.kapt") {
-            project.tasks.withType(getTaskClass("org.jetbrains.kotlin.gradle.internal.KaptGenerateStubsTask")).configureEach {
+        if (project.tasks.findByName("compileKotlin") != null) {
+            project.tasks.named("compileKotlin").configure {
                 it.dependsOn wsdl2JavaTask
             }
         }


### PR DESCRIPTION
If we find a task named `compileKotlin` then hook up the wsdl2java task to that one.