### PR TITLE
Add a flag to exclude java 8 xml dependencies during runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ plugins {
 | stabilizeAndMergeObjectFactory| false | If multiple WSDLs target the same package, merge their `ObjectFactory` classes. |
 | cxfVersion | "+" | Controls the CXF version used to generate code. |
 | cxfPluginVersion | "+" | Controls the CXF XJC-plugins version used to generate code. |
+| includeJava8XmlDependencies | true | If on Java 9 or later this flag includes xml libraries that were previously included with the JRE. Set to false if you use recent versions of Java and the Jakarta xml implementations. |
 
 Example setting of options:
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = 'com.yupzip'
-version = '2.2.0'
+version = '2.3.0'
 
 // stay compatible with the crowd
 sourceCompatibility = JavaVersion.VERSION_1_6

--- a/src/main/groovy/com/yupzip/wsdl2java/Wsdl2JavaPlugin.groovy
+++ b/src/main/groovy/com/yupzip/wsdl2java/Wsdl2JavaPlugin.groovy
@@ -30,7 +30,7 @@ class Wsdl2JavaPlugin implements Plugin<Project> {
         // Get implementation configuration and add Java 9+ dependencies if required.
         project.configurations.named("implementation").configure {
             it.withDependencies {
-                if (JavaVersion.current().isJava9Compatible()) {
+                if (JavaVersion.current().isJava9Compatible() && extension.includeJava8XmlDependencies) {
                     JAVA_9_DEPENDENCIES.each { dep -> it.add(project.dependencies.create(dep)) }
                 }
             }
@@ -47,7 +47,7 @@ class Wsdl2JavaPlugin implements Plugin<Project> {
                     it.add(project.dependencies.create("org.apache.cxf.xjcplugins:cxf-xjc-boolean:${cxfPluginVersion.get()}"))
                 }
 
-                if (JavaVersion.current().isJava9Compatible()) {
+                if (JavaVersion.current().isJava9Compatible() && extension.includeJava8XmlDependencies) {
                     JAVA_9_DEPENDENCIES.each { dep -> it.add(project.dependencies.create(dep)) }
                 }
             }

--- a/src/main/groovy/com/yupzip/wsdl2java/Wsdl2JavaPluginExtension.groovy
+++ b/src/main/groovy/com/yupzip/wsdl2java/Wsdl2JavaPluginExtension.groovy
@@ -36,4 +36,7 @@ class Wsdl2JavaPluginExtension {
     @Input
     String generatedWsdlDir = "build/generated/wsdl"
 
+    @Input
+    boolean includeJava8XmlDependencies = true;
+
 }


### PR DESCRIPTION
Jakarta libraries have the current implementation of java xml libraries. Including the old jaxb implementations can lead to classpath conflicts since they include identically named classes. This change includes a flag to prevent loading the old jaxb implementations at plugin runtime. The flag defaults true to maintain existing behavior. 