### PR TITLE
MISC: Updated plugin to reference ArrayList .size() instead of .size …

### DIFF
--- a/src/main/groovy/com/yupzip/wsdl2java/Wsdl2JavaTask.groovy
+++ b/src/main/groovy/com/yupzip/wsdl2java/Wsdl2JavaTask.groovy
@@ -51,8 +51,8 @@ class Wsdl2JavaTask extends DefaultTask {
             String wsdlPath = md5.digest(argsCopy[-1].toString().bytes).encodeHex().toString()
             File targetDir = new File(tmpDir, wsdlPath)
 
-            argsCopy.add(argsCopy.size - 1, '-d')
-            argsCopy.add(argsCopy.size - 1, targetDir)
+            argsCopy.add(argsCopy.size() - 1, '-d')
+            argsCopy.add(argsCopy.size() - 1, targetDir)
             String[] wsdl2JavaArgs = new String[argsCopy.size()]
             for (int i = 0; i < argsCopy.size(); i++)
                 wsdl2JavaArgs[i] = argsCopy[i]


### PR DESCRIPTION
Thanks so much for putting this update together to work with Gradle 7.x

We are getting an error on our Jenkins build server related to the following issue:

See: https://issues.apache.org/jira/browse/GROOVY-4094

This PR changes the task class to reference ArrayList size() explicitly which will resolve the issue for us.