### PR TITLE
Add lineEnding extension property to configure generated files line endings

### DIFF
--- a/src/main/groovy/com/yupzip/wsdl2java/LineEnding.groovy
+++ b/src/main/groovy/com/yupzip/wsdl2java/LineEnding.groovy
@@ -1,0 +1,31 @@
+package com.yupzip.wsdl2java
+
+enum LineEnding {
+    /**
+     * {@code \n} on unix systems, {@code \r\n} on windows systems.
+     */
+    PLATFORM_NATIVE(System.lineSeparator()),
+    /**
+     * {@code \r\n}
+     */
+    WINDOWS("\r\n"),
+    /**
+     * {@code \n}
+     */
+    UNIX("\n"),
+    /**
+     * {@code \r}
+     */
+    MAC_CLASSIC("\r");
+
+
+    private LineEnding(String value) {
+        this.value = value;
+    }
+
+    private final String value;
+
+    String getValue() {
+        return value;
+    }
+}

--- a/src/main/groovy/com/yupzip/wsdl2java/Wsdl2JavaPluginExtension.groovy
+++ b/src/main/groovy/com/yupzip/wsdl2java/Wsdl2JavaPluginExtension.groovy
@@ -22,6 +22,9 @@ class Wsdl2JavaPluginExtension {
     String encoding = Charset.defaultCharset().name()
 
     @Input
+    LineEnding lineEnding = LineEnding.PLATFORM_NATIVE
+
+    @Input
     boolean stabilize = false
 
     @Input

--- a/src/main/groovy/com/yupzip/wsdl2java/Wsdl2JavaTask.groovy
+++ b/src/main/groovy/com/yupzip/wsdl2java/Wsdl2JavaTask.groovy
@@ -10,8 +10,6 @@ import java.security.MessageDigest
 @CacheableTask
 class Wsdl2JavaTask extends DefaultTask {
 
-    private static final NEWLINE = System.getProperty("line.separator")
-
     @InputFiles
     @Classpath
     Configuration classpath
@@ -144,7 +142,7 @@ class Wsdl2JavaTask extends DefaultTask {
     }
 
     protected void switchToEncoding(File file) {
-        List<String> lines = file.getText().split(NEWLINE)
+        List<String> lines = file.getText().split(LineEnding.PLATFORM_NATIVE.value)
         file.delete()
 
         if (extension.stabilize) {
@@ -154,7 +152,8 @@ class Wsdl2JavaTask extends DefaultTask {
             stabilizeXmlSeeAlso(file, lines)
         }
 
-        String text = lines.join(NEWLINE) + NEWLINE  // want empty line last
+        String extensionLineEnding = extension.lineEnding.value
+        String text = lines.join(extensionLineEnding) + extensionLineEnding  // want empty line last
         file.withWriter(extension.encoding) { w -> w.write(text) }
     }
 


### PR DESCRIPTION
Hello !

In this pull request I added the possibility to configure the line endings of the generated code.

Here is the context:
In my company we use the Gradle Remote [Build Cache](https://docs.gradle.org/current/userguide/build_cache.html) to reduce the build time of our projects. We use static code analyzers (PMD and SpotBugs) configured with Gradle, and the whole source code is an input of the provided static analysis tasks.
For the projects that use this `wsdl2java` plugin, the line endings of the generated source code are different when the task is executed on a Linux machine and on a Windows machine. As a consequence the source code input is considered to be different between the two OSs by Gradle and we have a cache miss. Having the same line endings on the two OSs for the code generated by this plugin fixes our problem.

Best regards