### PR TITLE
Adaption for Gradle 9

### DIFF
--- a/src/main/groovy/com/yupzip/wsdl2java/Wsdl2JavaPlugin.groovy
+++ b/src/main/groovy/com/yupzip/wsdl2java/Wsdl2JavaPlugin.groovy
@@ -24,8 +24,22 @@ class Wsdl2JavaPlugin implements Plugin<Project> {
         def cxfVersion = project.provider { extension.cxfVersion }
         def cxfPluginVersion = project.provider { extension.cxfPluginVersion }
 
-        // Add new configuration for our plugin and add required dependencies to it later.
+        // Add new configuration for our plugin and add required dependencies to it.
         def wsdl2javaConfiguration = project.configurations.maybeCreate(WSDL2JAVA)
+        wsdl2javaConfiguration.withDependencies {
+            it.add(project.dependencies.create("org.apache.cxf:cxf-tools-wsdlto-databinding-jaxb:${cxfVersion.get()}"))
+            it.add(project.dependencies.create("org.apache.cxf:cxf-tools-wsdlto-frontend-jaxws:${cxfVersion.get()}"))
+            if (project.wsdl2java.wsdlsToGenerate.any { it.contains('-xjc-Xts') }) {
+                it.add(project.dependencies.create("org.apache.cxf.xjcplugins:cxf-xjc-ts:${cxfPluginVersion.get()}"))
+            }
+            if (project.wsdl2java.wsdlsToGenerate.any { it.contains('-xjc-Xbg') }) {
+                it.add(project.dependencies.create("org.apache.cxf.xjcplugins:cxf-xjc-boolean:${cxfPluginVersion.get()}"))
+            }
+
+            if (JavaVersion.current().isJava9Compatible() && extension.includeJava8XmlDependencies) {
+                JAVA_9_DEPENDENCIES.each { dep -> it.add(project.dependencies.create(dep)) }
+            }
+        }
 
         // Get implementation configuration and add Java 9+ dependencies if required.
         project.configurations.named("implementation").configure {
@@ -37,21 +51,6 @@ class Wsdl2JavaPlugin implements Plugin<Project> {
         }
 
         def wsdl2JavaTask = project.tasks.register(WSDL2JAVA_TASK, Wsdl2JavaTask.class) { task ->
-            wsdl2javaConfiguration.withDependencies {
-                it.add(project.dependencies.create("org.apache.cxf:cxf-tools-wsdlto-databinding-jaxb:${cxfVersion.get()}"))
-                it.add(project.dependencies.create("org.apache.cxf:cxf-tools-wsdlto-frontend-jaxws:${cxfVersion.get()}"))
-                if (project.wsdl2java.wsdlsToGenerate.any { it.contains('-xjc-Xts') }) {
-                    it.add(project.dependencies.create("org.apache.cxf.xjcplugins:cxf-xjc-ts:${cxfPluginVersion.get()}"))
-                }
-                if (project.wsdl2java.wsdlsToGenerate.any { it.contains('-xjc-Xbg') }) {
-                    it.add(project.dependencies.create("org.apache.cxf.xjcplugins:cxf-xjc-boolean:${cxfPluginVersion.get()}"))
-                }
-
-                if (JavaVersion.current().isJava9Compatible() && extension.includeJava8XmlDependencies) {
-                    JAVA_9_DEPENDENCIES.each { dep -> it.add(project.dependencies.create(dep)) }
-                }
-            }
-
             task.group = "Wsdl2Java"
             task.description = "Generate java source code from WSDL files."
             task.classpath = wsdl2javaConfiguration


### PR DESCRIPTION
Add dependencies to the `wsdl2javaConfiguration` immediately in order to avoid mutating it "after it has been resolved, consumed as a variant, or used for generating published metadata", see
https://docs.gradle.org/8.14.4/userguide/upgrading_version_8.html#mutate_configuration_after_locking